### PR TITLE
Adds a pinpointer to the hos locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -121,6 +121,7 @@
 		/obj/item/clothing/accessory/holster/handgun/waist,
 		/obj/item/weapon/melee/telebaton,
 		/obj/item/weapon/card/debit/preferred/department/security,
+		/obj/item/weapon/pinpointer,
 		/obj/item/weapon/storage/box/large/securitygear,
 	)
 


### PR DESCRIPTION
Adds a second pinpointer to the hos locker, It's too easy for the single pinpointer the station has to just go missing
Note that this is not a repeat of my previous PR why was an attempt to add a pinpointer pinpointer

:cl:
Adds a second pinpointer to the head of securities locker